### PR TITLE
Bypass `kaltura` related video attachment handling

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -530,7 +530,7 @@ class Attachment < ActiveRecord::Base
       self.namespace = infer_namespace
     end
 
-    self.media_entry_id ||= "maybe" if new_record? && previewable_media?
+    # self.media_entry_id ||= "maybe" if new_record? && previewable_media?
   end
   protected :default_values
 


### PR DESCRIPTION
Per comment
https://github.com/instructure/canvas-lms/issues/2327#issuecomment-2001951659, commented out attachment handling code that assumes `kaltura` media handling.